### PR TITLE
Fix LICENSE file installed directly in site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,6 @@ keywords = ['classification', 'NiaPy', 'NiaAML', 'scikit-learn', 'nature-inspire
 homepage = "https://github.com/lukapecnik/NiaAML-GUI"
 repository = "https://github.com/lukapecnik/NiaAML-GUI"
 readme = "README.rst"
-include = [
-    "LICENSE"
-]
 
 [tool.poetry.dependencies]
 python = "^3.6.1"


### PR DESCRIPTION
By removing “`include = ["LICENSE"]`” from `pyproject.toml`, poetry will no longer install the `LICENSE` file directly under site-packages, but it will still (automatically) include it in the `.tar.gz` sdist and in the wheel’s dist-info.